### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean of type com.netflix.spectator.api.Registry available issue

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -72,7 +72,6 @@ import org.springframework.web.client.RestTemplate
 import redis.clients.jedis.JedisPool
 import retrofit.Endpoint
 import java.util.HashMap;
-import com.netflix.spectator.api.DefaultRegistry
 
 import jakarta.servlet.*
 import java.util.concurrent.ExecutorService
@@ -145,13 +144,8 @@ class GateConfig extends RedisHttpSessionConfiguration {
     Executors.newCachedThreadPool()
   }
 
-//  @Autowired
-//  Registry registry
-
-  @Bean
-  Registry getRegistry() {
-    return new DefaultRegistry();
-  }
+  @Autowired
+  Registry registry
 
   @Autowired
   EurekaLookupService eurekaLookupService


### PR DESCRIPTION
Fixed as suggested in:
spring-projects/spring-boot#33413

The 3.0 release notes link to the dedicated migration guide, which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70