### PR TITLE
Added CD to gate using githubAction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,12 @@ allprojects {
   test {
     testLogging {
       exceptionFormat = 'full'
+      afterSuite { desc, result ->
+        if (!desc.parent) {
+          println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+          println "Report file: ${reports.html.entryPoint}"
+        }
+      }
     }
     useJUnitPlatform()
   }

--- a/gate-api-tck/src/test/kotlin/com/netflix/spinnaker/gate/api/test/GateFixtureTest.kt
+++ b/gate-api-tck/src/test/kotlin/com/netflix/spinnaker/gate/api/test/GateFixtureTest.kt
@@ -22,14 +22,15 @@ import dev.minutest.rootContext
 class GateFixtureTest : JUnit5Minutests {
 
   fun tests() = rootContext<Fixture> {
-    /*context("a gate integration test environment") {
+    context("a gate integration test environment") {
       gateFixture {
         Fixture()
       }
 
-      test("service starts") { *//* no-op *//* }
-    }*/
+      test("service starts") { /* no-op */ }
+    }
   }
 
   private inner class Fixture : GateFixture()
 }
+

--- a/gate-core/gate-core.gradle
+++ b/gate-core/gate-core.gradle
@@ -27,7 +27,6 @@ dependencies {
   implementation "com.squareup.okhttp:okhttp"
   implementation "com.squareup.okhttp:okhttp-urlconnection:2.7.5"
   implementation "com.squareup.okhttp:okhttp-apache:2.7.5"
-  implementation "junit:junit:4.13.2"
 
   implementation "io.spinnaker.fiat:fiat-api:$fiatVersion"
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"

--- a/gate-core/src/test/java/com/netflix/spinnaker/gate/services/TaskServiceTest.java
+++ b/gate-core/src/test/java/com/netflix/spinnaker/gate/services/TaskServiceTest.java
@@ -23,14 +23,11 @@ import com.netflix.spinnaker.gate.services.internal.OrcaService;
 import com.netflix.spinnaker.gate.services.internal.OrcaServiceSelector;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {TaskService.class, TaskServiceProperties.class})
 public class TaskServiceTest {
 

--- a/gate-plugins-test/src/test/kotlin/com/netflix/spinnaker/gate/plugins/test/GatePluginsTest.kt
+++ b/gate-plugins-test/src/test/kotlin/com/netflix/spinnaker/gate/plugins/test/GatePluginsTest.kt
@@ -29,7 +29,7 @@ import strikt.assertions.isEqualTo
 class GatePluginsTest : PluginsTck<GatePluginsFixture>() {
 
   fun tests() = rootContext<GatePluginsFixture> {
-    /*context("a gate integration test environment and a gate plugin") {
+    context("a gate integration test environment and a gate plugin") {
       serviceFixture {
         GatePluginsFixture()
       }
@@ -66,6 +66,6 @@ class GatePluginsTest : PluginsTck<GatePluginsFixture>() {
           that(response.status).isEqualTo(404)
         }
       }
-    }*/
+    }
   }
 }

--- a/gate-plugins/gate-plugins.gradle
+++ b/gate-plugins/gate-plugins.gradle
@@ -34,3 +34,6 @@ dependencies {
   implementation "org.springframework:spring-web"
   implementation "org.pf4j:pf4j-update:+"
 }
+test {
+  useJUnitPlatform()
+}

--- a/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
+++ b/gate-web/src/test/groovy/com/netflix/spinnaker/gate/MainSpec.java
@@ -5,15 +5,12 @@ import com.netflix.spinnaker.gate.health.DownstreamServicesHealthIndicator;
 import com.netflix.spinnaker.gate.services.internal.*;
 import com.netflix.spinnaker.kork.client.ServiceClientProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {Main.class})
 @ActiveProfiles("test")
 @TestPropertySource(properties = {"spring.config.location=classpath:gate-test.yml"})


### PR DESCRIPTION
## Summary
Adding CD to gate using github action. Now dev quay img will be automatically changed to ns=cvetarget cluster in gate.yml, upon successful pre steps.

### How changes are verified
Pushed these chnges on branch=aman and verified that latest created quay img is reflected on cvetarget - checked by viewing gate.yml https://github.com/OpsMx/gate-oes/actions/runs/5408520370/jobs/9827671804

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA