### PR TITLE
fix for circular dependency

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -102,7 +102,6 @@ class GateConfig extends RedisHttpSessionConfiguration {
   }
 
   @SuppressWarnings('GrDeprecatedAPIUsage')
-  @Autowired
   GateConfig(@Value('${server.session.timeout-in-seconds:3600}') int maxInactiveIntervalInSeconds) {
     super.setMaxInactiveIntervalInSeconds(maxInactiveIntervalInSeconds)
   }


### PR DESCRIPTION
fix for jira: https://devopsmx.atlassian.net/browse/OP-20993

Removed autowiring through constructor while there is a setter injection for parameter `serviceClientProvider` in GateConfig class