### PR TITLE
Oes 1.30.1

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.gate.config;
 
 import com.google.common.base.Splitter;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,7 +8,6 @@ import java.lang.annotation.Target;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,8 +35,7 @@ public class PostConnectionConfiguringJedisConnectionFactory extends JedisConnec
   @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER})
   @Retention(RetentionPolicy.RUNTIME)
   @Qualifier
-  @interface ConnectionPostProcessor {
-  }
+  @interface ConnectionPostProcessor {}
 
   @Autowired
   @Lazy


### PR DESCRIPTION
fix for jira : https://devopsmx.atlassian.net/browse/OP-20993

when using `redis:
 connection: redis://xxxxxxxxxxxx.amazonaws.com:6379
 configuration:
  secure: true`  `ConfigureRedisAction` bean from `GateConfig` class is being created, which is used by `PostConnectionConfiguringJedisConnectionFactory` class, which is a component class and introducing circular dependency. Hence made lazy intialization for PostConnectionConfiguringJedisConnectionFactory class's `ConfigureRedisAction`