### PR TITLE
removed the autowired annotation as no bean is required to be autowired

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
@@ -66,7 +66,6 @@ public class PostConnectionConfiguringJedisConnectionFactory extends JedisConnec
     }
   }
 
-  @Autowired
   public PostConnectionConfiguringJedisConnectionFactory(
       @Value("${redis.connection:redis://localhost:6379}") String connectionUri,
       @Value("${redis.timeout:2000}") int timeout) {


### PR DESCRIPTION
With multiple constructors annotated with '@Autowired' annotation spring complains of 'Invalid autowire-marked constructor' so removing the annotation for one of the constructors where it does not require any parameters to be autowired because we are assigning a default instance for while defining the constructor