### PR TITLE
[Cisco CustomLink] - Added SplunkLog Controller

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SplunkLogController.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/controllers/SplunkLogController.java
@@ -1,0 +1,45 @@
+package com.netflix.spinnaker.gate.controllers;
+
+import io.swagger.annotations.ApiOperation;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/splunk")
+@ConditionalOnProperty("splunk.log.enabled", matchIfMissing = false)
+public class SplunkLogController {
+
+  private static final Logger log = LoggerFactory.getLogger(SplunkLogController.class);
+
+  // Sample baseURL = https://hostURL?paramsKey=paramsValue&index=CLUSTER_NAME%20pod=POD_NAME
+  @Value("${splunk.log.baseURL}")
+  private String baseURL;
+
+  @Value("${splunk.log.clusterName}")
+  private String clusterName;
+
+  @ApiOperation("Retrieve splunk logs")
+  @GetMapping("/logs/{podName}")
+  public ResponseEntity<byte[]> getSplunkLogs(@PathVariable("podName") String podName)
+      throws IOException {
+    String logUrl = baseURL.replace("CLUSTER_NAME", clusterName).replace("POD_NAME", podName);
+    log.info("Inside SplunkLogController - getSplunkLogs(), splunk Log URL : " + logUrl);
+
+    try (InputStream in = new URL(logUrl).openStream()) {
+      byte[] fileContents = in.readAllBytes();
+      return ResponseEntity.ok()
+          .header("Content-Disposition", "attachment; filename=log.zip")
+          .body(fileContents);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21250)
**Project Doc :** NA

**Feature :** Added new controller to get splunk logs for Cisco

### How changes are verified
Tested locally with sample app & gate service, redirection is happening.

### Highlights
1. baseURL, podURL, clusterName should come from .hal/default/profiles/gate-local.yml
2. podName will be supplied by gateURL (present in .hal/default/profiles/orca-local.yml)

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** 
1. Aman will test this feature with latest gate quay img on k8s setup, redirection should work fine.
2. If step1 is passed, QA will test this feature with different authN mechanism to be 100% sure