### PR TITLE
Fixed the xalan version issue. xalan 2.7.2 has a vulnerability. Replaced the version with 2.7.3. OP-21545

### DIFF
--- a/gate-saml/gate-saml.gradle
+++ b/gate-saml/gate-saml.gradle
@@ -9,14 +9,16 @@ dependencies{
   implementation("org.apache.santuario:xmlsec:3.0.2"){
     force(true)
   }
+  implementation "xalan:xalan:2.7.3"
+  implementation "xalan:serializer:2.7.3"
   implementation 'org.springframework:spring-context'
   implementation 'org.springframework.session:spring-session-core'
   implementation 'org.springframework.boot:spring-boot-autoconfigure'
   implementation("org.owasp.esapi:esapi:2.5.2.0")
   implementation("org.bouncycastle:bcprov-ext-jdk15on:1.70")
-  implementation "org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE"
+  implementation ('org.springframework.security.extensions:spring-security-saml2-core:1.0.9.RELEASE') {
+    exclude group: "xalan", module: "xalan:2.7.2"
+  }
   implementation "org.springframework.security.extensions:spring-security-saml-dsl-core:1.0.5.RELEASE"
-
-  // https://mvnrepository.com/artifact/org.springframework.security/spring-security-saml2-service-provider
   implementation group: 'org.springframework.security', name: 'spring-security-saml2-service-provider', version: '6.0.2'
 }


### PR DESCRIPTION
Fixed the xalan version issue. xalan 2.7.2 has a vulnerability. Replaced the version with 2.7.3. OP-21545

jira for issue: https://devopsmx.atlassian.net/browse/OP-21545

verified build.

