### PR TITLE
refactoring code to fix circular dependency

### DIFF
--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/GateConfig.groovy
@@ -123,21 +123,9 @@ class GateConfig extends RedisHttpSessionConfiguration {
     new RestTemplate()
   }
 
-  /**
-   * Always disable the ConfigureRedisAction that Spring Boot uses internally. Instead we use one
-   * qualified with @ConnectionPostProcessor. See
-   * {@link PostConnectionConfiguringJedisConnectionFactory}.
-   * */
   @Bean
   @Primary
   ConfigureRedisAction springBootConfigureRedisAction() {
-    return ConfigureRedisAction.NO_OP
-  }
-
-  @Bean
-  @ConnectionPostProcessor
-  @ConditionalOnProperty("redis.configuration.secure")
-  ConfigureRedisAction connectionPostProcessorConfigureRedisAction() {
     return ConfigureRedisAction.NO_OP
   }
 

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/PostConnectionConfiguringJedisConnectionFactory.java
@@ -66,29 +66,6 @@ public class PostConnectionConfiguringJedisConnectionFactory extends JedisConnec
     }
   }
 
-  public PostConnectionConfiguringJedisConnectionFactory(
-      @Value("${redis.connection:redis://localhost:6379}") String connectionUri,
-      @Value("${redis.timeout:2000}") int timeout) {
-
-    this.configureRedisAction = new ConfigureNotifyKeyspaceEventsAction();
-
-    URI redisUri = URI.create(connectionUri);
-    setHostName(redisUri.getHost());
-    setPort(redisUri.getPort());
-    setTimeout(timeout);
-
-    if (redisUri.getUserInfo() != null) {
-      List<String> userInfo = USER_INFO_SPLITTER.splitToList(redisUri.getUserInfo());
-      if (userInfo.size() >= 2) {
-        setPassword(userInfo.get(1));
-      }
-    }
-
-    if (redisUri.getScheme().equals("rediss")) {
-      setUseSsl(true);
-    }
-  }
-
   @Override
   protected JedisConnection postProcessConnection(JedisConnection connection) {
     if (!ranConfigureRedisAction) {

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisSecureConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisSecureConfig.java
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.gate.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.ConfigureRedisAction;
+
+@Configuration
+public class RedisSecureConfig {
+
+  /**
+   * Always disable the ConfigureRedisAction that Spring Boot uses internally. Instead, we use one
+   * qualified with @ConnectionPostProcessor. See
+   * {@link PostConnectionConfiguringJedisConnectionFactory, GateConfig}.
+   * */
+  @Bean
+  @PostConnectionConfiguringJedisConnectionFactory.ConnectionPostProcessor
+  @ConditionalOnProperty("redis.configuration.secure")
+  ConfigureRedisAction connectionPostProcessorConfigureRedisAction() {
+    return ConfigureRedisAction.NO_OP;
+  }
+}

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisSecureConfig.java
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/config/RedisSecureConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 OpsMx, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.spinnaker.gate.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;


### PR DESCRIPTION
jira: https://devopsmx.atlassian.net/browse/OP-20993

In gate circular dependency arises between Gateconfig and postConnectionConfiguringJedisConnectionFactory classes when redis.configuration.secure: true property is added in gate-local.yml

already tried following methods to resolve this issue but did not work:

Lazy intialization:
https://devopsmx.atlassian.net/browse/OP-21162
setter Injection
Adding additional constructor:
https://github.com/OpsMx/gate-oes/pull/39
Now trying to solve this issue by refactoring code