### PR TITLE
fix(saml): Functionality modified to make it similar to OSS

### DIFF
--- a/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/Saml2UserAttributeMapping.java
+++ b/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/Saml2UserAttributeMapping.java
@@ -16,6 +16,7 @@
 
 package com.opsmx.spinnaker.gate.security.saml;
 
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -29,6 +30,17 @@ public class Saml2UserAttributeMapping {
 
   private String firstName = "user.firstName";
   private String lastName = "user.lastName";
-  private String roles = "memberOf";
+  private Roles roles;
   private String email = "user.email";
+
+  @Data
+  @Configuration
+  @ConfigurationProperties(prefix = "spring.security.saml2.user-attribute-mapping.roles")
+  static class Roles {
+    private String attributeName = "memberOf";
+    private List<String> requiredRoles;
+    private boolean sortRoles = false;
+    private boolean forceLowercaseRoles = true;
+    private String rolesDelimiter;
+  }
 }


### PR DESCRIPTION
These includes:

- Included RememberMeServices
- Sorting the roles based on config
- Forcing lowercase roles based on config
- Asserting user, based on the allowed roles in the configuration
- ACS endpoint can now be overridden
- Configuration enabled to provide the SP EntityId

Note : There are changes in the configurations as well, Below are the updated one:

```
spring:
  security:
    saml2:
      enabled: true
      registration-id: spinnaker #Mandatory field - This is exactly same as the last path variable of the SSO/ACS url. Eg : if the URL is : http://localhost:8084/gate/saml/sso - The the last path variable **sso** will be considered as the registrationId
      relyingparty:
        registration:
          spinnaker: #Mandatory field - This should be exactly same value as registration-id
            entity-id: spinnaker-cve #Optional - if not provided then, spring security defaults the value to /saml2/service-provider-metadata/{registrationId}
            acs:
              location: http://localhost:8084/saml2/gate/sso/spinnaker #Optional field - This the configuration that allows user to override the ACS endpoint, Make sure the same endpoint is configured in IDP under SSO url, if not provided spring security will use the default endpoint: /login/saml2/sso/{registrationId}
            assertingparty:
              metadata-uri: https://idp.com/app/key/sso/saml/metadata
      user-attribute-mapping:
        firstName: firstName
        lastName: lastName
        roles:
          attributeName: memberOf 
          sortRoles: true
          forceLowercaseRoles: true
          rolesDelimiter: ","
        email: email
```
