### PR TITLE
Fixed context null issue in AuthConfigTest

### DIFF
--- a/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
+++ b/gate-core/src/test/groovy/com/netflix/spinnaker/gate/config/AuthConfigTest.groovy
@@ -19,6 +19,8 @@ import com.netflix.spinnaker.fiat.shared.FiatClientConfigurationProperties
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.fiat.shared.FiatStatus
 import org.springframework.boot.autoconfigure.security.SecurityProperties
+import org.springframework.context.ApplicationContext
+import org.springframework.context.support.GenericApplicationContext
 import org.springframework.security.config.annotation.ObjectPostProcessor
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -27,6 +29,9 @@ import spock.lang.Specification
 import java.util.stream.Collectors
 
 class AuthConfigTest extends Specification {
+
+  private GenericApplicationContext context = new GenericApplicationContext()
+
   @SuppressWarnings("GroovyAccessibility")
   def "test webhooks are unauthenticated by default"() {
     given:
@@ -47,7 +52,7 @@ class AuthConfigTest extends Specification {
     def httpSecurity = new HttpSecurity(
       Mock(ObjectPostProcessor),
       Mock(AuthenticationManagerBuilder),
-      new HashMap<Class<?>, Object>()
+      getSharedObjects()
     )
 
     when:
@@ -86,14 +91,14 @@ class AuthConfigTest extends Specification {
     def httpSecurity = new HttpSecurity(
       Mock(ObjectPostProcessor),
       Mock(AuthenticationManagerBuilder),
-      new HashMap<Class<?>, Object>()
+      getSharedObjects()
     )
 
     when:
     authConfig.configure(httpSecurity)
 
     then:
-    def filtered = httpSecurity.getUrlMappings()
+    def filtered = httpSecurity.authorizeRequests().getUrlMappings()
       .stream()
       .filter({ it -> it.requestMatcher.getPattern() == "/webhooks/**" })
       .filter( { it ->
@@ -101,5 +106,12 @@ class AuthConfigTest extends Specification {
       })
       .collect(Collectors.toList())
     filtered.size() == 1
+  }
+
+  private HashMap<Class<?>, Object> getSharedObjects(){
+    HashMap map = new HashMap<Class<?>, Object>()
+    context.refresh()
+    map.put(ApplicationContext.class, context)
+    return map;
   }
 }


### PR DESCRIPTION
**Ref** : https://github.com/spinnaker/gate/pull/1765
**Issue** :
```
Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
java.lang.NullPointerException: Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
	at org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer.<init>(ExpressionUrlAuthorizationConfigurer.java:109)
	at org.springframework.security.config.annotation.web.builders.HttpSecurity.authorizeRequests(HttpSecurity.java:1265)
	at com.netflix.spinnaker.gate.config.AuthConfig.configure(AuthConfig.java:76)
	at com.netflix.spinnaker.gate.config.AuthConfigTest.test webhooks are unauthenticated by default(AuthConfigTest.groovy:51)

Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
java.lang.NullPointerException: Cannot invoke "org.springframework.context.ApplicationContext.getBeanNamesForType(java.lang.Class)" because "context" is null
	at org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer.<init>(ExpressionUrlAuthorizationConfigurer.java:109)
	at org.springframework.security.config.annotation.web.builders.HttpSecurity.authorizeRequests(HttpSecurity.java:1265)
	at com.netflix.spinnaker.gate.config.AuthConfig.configure(AuthConfig.java:76)
	at com.netflix.spinnaker.gate.config.AuthConfigTest.test webhooks can be configured to be authenticated(AuthConfigTest.groovy:86)
```

**Testing** : context is null issue - resolved