### PR TITLE
fix(saml): Functionality modified to make it similar to OSS

### DIFF
--- a/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/Saml2UserAttributeMapping.java
+++ b/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/Saml2UserAttributeMapping.java
@@ -16,6 +16,7 @@
 
 package com.opsmx.spinnaker.gate.security.saml;
 
+import java.util.List;
 import lombok.Data;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -29,7 +30,15 @@ public class Saml2UserAttributeMapping {
 
   private String firstName = "user.firstName";
   private String lastName = "user.lastName";
-  private String roles = "memberOf";
+  private Roles roles = new Roles();
   private String email = "user.email";
-  private String rolesDelimiter;
+
+  @Data
+  public static class Roles {
+    private String attributeName = "memberOf";
+    private List<String> requiredRoles;
+    private boolean sortRoles = false;
+    private boolean forceLowercaseRoles = true;
+    private String rolesDelimiter;
+  }
 }

--- a/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/SamlSecurityConfiguration.java
+++ b/gate-saml/src/main/java/com/opsmx/spinnaker/gate/security/saml/SamlSecurityConfiguration.java
@@ -24,28 +24,38 @@ import com.netflix.spinnaker.gate.security.SpinnakerAuthConfig;
 import com.netflix.spinnaker.gate.services.PermissionService;
 import com.netflix.spinnaker.kork.core.RetrySupport;
 import com.netflix.spinnaker.security.User;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.security.saml2.Saml2RelyingPartyProperties;
 import org.springframework.boot.autoconfigure.session.DefaultCookieSerializerCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.saml2.provider.service.authentication.OpenSaml4AuthenticationProvider;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
+import org.springframework.security.saml2.provider.service.web.authentication.Saml2WebSsoAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.RememberMeServices;
+import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
+import org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 
 @Slf4j
 @Configuration
@@ -53,6 +63,9 @@ import org.springframework.security.web.SecurityFilterChain;
 @SpinnakerAuthConfig
 @ConditionalOnExpression("${spring.security.saml2.enabled:false}")
 public class SamlSecurityConfiguration {
+
+  @Value("${spring.security.saml2.registration-id}")
+  private String registrationId;
 
   @Autowired private AuthConfig authConfig;
 
@@ -68,18 +81,118 @@ public class SamlSecurityConfiguration {
 
   @Autowired private FiatClientConfigurationProperties fiatClientConfigurationProperties;
 
+  @Autowired private Saml2RelyingPartyProperties relyingPartyProperties;
+
+  private URI acsLocation;
+
+  private String loginProcessingUrl;
+
+  public static final String defaultFilterUrl =
+      "{baseUrl}" + Saml2WebSsoAuthenticationFilter.DEFAULT_FILTER_PROCESSES_URI;
+
   @Bean
-  public SecurityFilterChain samlFilterChain(HttpSecurity http) throws Exception {
+  public UserDetailsService userDetailsService() {
+    return username -> {
+      User user = new User();
+      user.setUsername(username);
+      return user;
+    };
+  }
+
+  @Bean
+  public RememberMeServices rememberMeServices(UserDetailsService userDetailsService) {
+    TokenBasedRememberMeServices rememberMeServices =
+        new TokenBasedRememberMeServices("password", userDetailsService);
+    rememberMeServices.setCookieName("cookieName");
+    rememberMeServices.setParameter("rememberMe");
+    return rememberMeServices;
+  }
+
+  @Bean
+  public OpenSaml4AuthenticationProvider authenticationProvider() {
+    var authProvider = new OpenSaml4AuthenticationProvider();
+    authProvider.setResponseAuthenticationConverter(extractUserDetails());
+    return authProvider;
+  }
+
+  @Bean
+  public ProviderManager authenticationManager(
+      OpenSaml4AuthenticationProvider authenticationProvider) {
+    return new ProviderManager(authenticationProvider);
+  }
+
+  @Bean
+  public Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter(
+      RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
+      AuthenticationManager authenticationManager) {
+    log.info(
+        "ACS endpoint configured : {}",
+        relyingPartyProperties.getRegistration().get(registrationId).getAcs().getLocation());
+    Saml2WebSsoAuthenticationFilter saml2WebSsoAuthenticationFilter;
+    if (!relyingPartyProperties
+        .getRegistration()
+        .get(registrationId)
+        .getAcs()
+        .getLocation()
+        .equalsIgnoreCase(defaultFilterUrl)) {
+      initAcsUri();
+      saml2WebSsoAuthenticationFilter =
+          new Saml2WebSsoAuthenticationFilter(
+              relyingPartyRegistrationRepository, loginProcessingUrl);
+    } else {
+      saml2WebSsoAuthenticationFilter =
+          new Saml2WebSsoAuthenticationFilter(relyingPartyRegistrationRepository);
+    }
+
+    saml2WebSsoAuthenticationFilter.setAuthenticationManager(authenticationManager);
+    saml2WebSsoAuthenticationFilter.setSecurityContextRepository(
+        new HttpSessionSecurityContextRepository());
+    saml2WebSsoAuthenticationFilter.setSessionAuthenticationStrategy(
+        new ChangeSessionIdAuthenticationStrategy());
+
+    return saml2WebSsoAuthenticationFilter;
+  }
+
+  private void initAcsUri() {
+    try {
+      acsLocation =
+          new URI(
+              relyingPartyProperties.getRegistration().get(registrationId).getAcs().getLocation());
+      loginProcessingUrl = acsLocation.getPath().replace(registrationId, "{registrationId}");
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    } catch (Exception e) {
+      log.error("Exception occurred while reading the ACS endpoint : ", e);
+      throw e;
+    }
+  }
+
+  @Bean
+  public SecurityFilterChain samlFilterChain(
+      HttpSecurity http,
+      RememberMeServices rememberMeServices,
+      Saml2WebSsoAuthenticationFilter webSsoAuthenticationFilter,
+      ProviderManager authenticationManager)
+      throws Exception {
 
     log.info("Configuring SAML Security");
-
-    OpenSaml4AuthenticationProvider authenticationProvider = new OpenSaml4AuthenticationProvider();
-    authenticationProvider.setResponseAuthenticationConverter(extractUserDetails());
 
     authConfig.configure(http);
 
     http.saml2Login(
-            saml2 -> saml2.authenticationManager(new ProviderManager(authenticationProvider)))
+            saml2 -> {
+              saml2.authenticationManager(authenticationManager);
+              if (!relyingPartyProperties
+                  .getRegistration()
+                  .get(registrationId)
+                  .getAcs()
+                  .getLocation()
+                  .equalsIgnoreCase(defaultFilterUrl)) {
+                saml2.loginProcessingUrl(loginProcessingUrl);
+              }
+            })
+        .rememberMe(remember -> remember.rememberMeServices(rememberMeServices))
+        .addFilter(webSsoAuthenticationFilter)
         .saml2Logout(Customizer.withDefaults());
 
     return http.build();
@@ -94,46 +207,55 @@ public class SamlSecurityConfiguration {
         OpenSaml4AuthenticationProvider.createDefaultResponseAuthenticationConverter();
 
     return responseToken -> {
-      List<String> roles = Collections.emptyList();
-      log.info("responseToken : {}", responseToken);
-      if (responseToken.getToken() != null) {
-        log.info("responseToken.getToken() : {}", responseToken.getToken());
-        log.info("responseToken.getToken().getSaml2Response() : {}", responseToken.getToken().getSaml2Response());
-        log.info("responseToken.getToken().getDetails() : {}", responseToken.getToken().getDetails());
-        log.info("responseToken.getToken().getPrincipal() : {}", responseToken.getToken().getPrincipal());
-        log.info("responseToken.getToken().getAuthorities() : {}", responseToken.getToken().getAuthorities());
-      }
+      List<String> roles = new ArrayList<>();
+      log.debug("responseToken : {}", responseToken);
       Saml2Authentication authentication = delegate.convert(responseToken);
       Saml2AuthenticatedPrincipal principal =
           (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
 
-      log.info("responseToken after conversion : {}", authentication);
-      log.info("responseToken principal after conversion : {}", principal);
+      log.debug("role attribute in config : {}", saml2UserAttributeMapping.getRoles());
+      log.debug("firstName attribute in config : {}", saml2UserAttributeMapping.getFirstName());
+      log.debug("lastName attribute in config : {}", saml2UserAttributeMapping.getLastName());
+      log.debug("email attribute in config : {}", saml2UserAttributeMapping.getEmail());
+      log.debug(
+          "rolesDelimiter in config : {}",
+          saml2UserAttributeMapping.getRoles().getRolesDelimiter());
 
-      log.info("role attribute in config : {}", saml2UserAttributeMapping.getRoles());
-      log.info("firstName attribute in config : {}", saml2UserAttributeMapping.getFirstName());
-      log.info("lastName attribute in config : {}", saml2UserAttributeMapping.getLastName());
-      log.info("email attribute in config : {}", saml2UserAttributeMapping.getEmail());
-
-      List<String> rolesFromIdp = principal.getAttribute(saml2UserAttributeMapping.getRoles());
+      List<String> rolesExtractedFromIDP =
+          principal.getAttribute(saml2UserAttributeMapping.getRoles().getAttributeName());
       String firstName = principal.getFirstAttribute(saml2UserAttributeMapping.getFirstName());
       String lastName = principal.getFirstAttribute(saml2UserAttributeMapping.getLastName());
       String email = principal.getFirstAttribute(saml2UserAttributeMapping.getEmail());
 
-      Set<GrantedAuthority> authorities = new HashSet<>();
-      if (rolesFromIdp != null && saml2UserAttributeMapping.getRolesDelimiter()!=null) {
-        roles = Arrays.stream(rolesFromIdp.get(0).split(saml2UserAttributeMapping.getRolesDelimiter())).collect(Collectors.toList());
-        log.info("roles size extracted from responseToken : {}", roles.size());
-        roles.stream().map(SimpleGrantedAuthority::new).forEach(authorities::add);
-      } else {
-        authorities.addAll(authentication.getAuthorities());
-      }
-      log.info("roles extracted from responseToken : {}", roles);
-      log.info("firstName extracted from responseToken : {}", firstName);
-      log.info("lastName extracted from responseToken : {}", lastName);
-      log.info("email extracted from responseToken : {}", email);
       Assertion assertion = responseToken.getResponse().getAssertions().get(0);
       String username = assertion.getSubject().getNameID().getValue();
+
+      if (rolesExtractedFromIDP != null) {
+        if (saml2UserAttributeMapping.getRoles().getRolesDelimiter() != null) {
+          for (String role : rolesExtractedFromIDP) {
+            roles.addAll(
+                Arrays.stream(role.split(saml2UserAttributeMapping.getRoles().getRolesDelimiter()))
+                    .toList());
+          }
+        } else {
+          roles = rolesExtractedFromIDP;
+        }
+        if (saml2UserAttributeMapping.getRoles().isForceLowercaseRoles()) {
+          roles = roles.stream().map(String::toLowerCase).toList();
+        }
+
+        if (saml2UserAttributeMapping.getRoles().isSortRoles()) {
+          roles = roles.stream().sorted().toList();
+        }
+        if (saml2UserAttributeMapping.getRoles().getRequiredRoles() != null) {
+          if (!roles.containsAll(saml2UserAttributeMapping.getRoles().getRequiredRoles())) {
+            throw new BadCredentialsException(
+                String.format(
+                    "User %s does not have all roles %s",
+                    username, saml2UserAttributeMapping.getRoles().getRequiredRoles()));
+          }
+        }
+      }
 
       User user = new User();
       user.setRoles(roles);
@@ -142,6 +264,12 @@ public class SamlSecurityConfiguration {
       user.setLastName(lastName);
       user.setEmail(email);
       user.setAllowedAccounts(allowedAccountsSupport.filterAllowedAccounts(username, roles));
+
+      log.debug("username extracted from responseToken : {}", username);
+      log.debug("firstName extracted from responseToken : {}", firstName);
+      log.debug("lastName extracted from responseToken : {}", lastName);
+      log.debug("email extracted from responseToken : {}", email);
+      log.debug("roles extracted from responseToken : {}", roles);
 
       loginWithRoles(username, roles);
 


### PR DESCRIPTION
These includes:

- Included RememberMeServices
- Sorting the roles based on config
- Forcing lowercase roles based on config
- Asserting user, based on the allowed roles in the configuration
- ACS endpoint can now be overridden
- Configuration enabled to provide the SP EntityId