### PR TITLE
OP-21877 Fixed com.google.guava cve by upgrading it to 33.0.0-jre. CVE-2023-3635

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:+"
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
-  implementation "com.google.guava:guava:31.1-jre"
+  implementation "com.google.guava:guava"
 
   implementation "com.squareup.okhttp:okhttp:2.7.5"
   implementation "com.squareup.okhttp:okhttp-urlconnection:2.7.5"


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21877
Summary : Upgraded com.google.guava version
Testing :

compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing