### PR TITLE
OP-21877 Fixed com.google.guava cve by excluding graphql-java. CVE-2023-3635

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -47,8 +47,12 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-aop"
   implementation "io.github.resilience4j:resilience4j-spring-boot2"
 
-  implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1"
-  implementation "com.graphql-java-kickstart:graphql-java-tools:6.0.2"
+  implementation ('com.graphql-java-kickstart:graphql-spring-boot-starter:15.1.0') {
+    exclude group: "com.graphql-java", module: "graphql-java"
+  }
+  implementation ('com.graphql-java-kickstart:graphql-java-tools:13.1.1') {
+    exclude group: "com.graphql-java", module: "graphql-java"
+  }
   implementation "org.apache.groovy:groovy-json"
   runtimeOnly "io.spinnaker.kork:kork-runtime"
   runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"

--- a/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
+++ b/gate-web/src/main/groovy/com/netflix/spinnaker/gate/Main.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.gate
 
-import graphql.kickstart.spring.web.boot.GraphQLWebsocketAutoConfiguration
 import org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthContributorAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.groovy.template.GroovyTemplateAutoConfiguration
@@ -37,8 +36,7 @@ import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder
   exclude = [
     GroovyTemplateAutoConfiguration,
     GsonAutoConfiguration,
-    LdapHealthContributorAutoConfiguration,
-//    GraphQLWebsocketAutoConfiguration
+    LdapHealthContributorAutoConfiguration
   ]
 )
 class Main {


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21877
Summary : Removed graphql-java jar as we no longer use this module in our code.
Testing :

compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing