### PR TITLE
OP-21877 By removing graphql jar we are not able to start gate service. We reverted the change for now.

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -47,12 +47,8 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-aop"
   implementation "io.github.resilience4j:resilience4j-spring-boot2"
 
-  implementation ('com.graphql-java-kickstart:graphql-spring-boot-starter:15.1.0') {
-    exclude group: "com.graphql-java", module: "graphql-java"
-  }
-  implementation ('com.graphql-java-kickstart:graphql-java-tools:13.1.1') {
-    exclude group: "com.graphql-java", module: "graphql-java"
-  }
+  implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1"
+  implementation "com.graphql-java-kickstart:graphql-java-tools:6.0.2"
   implementation "org.apache.groovy:groovy-json"
   runtimeOnly "io.spinnaker.kork:kork-runtime"
   runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21877
Summary : Removed graphql-java jar but the gate service is not starting. Reverted the change for now.
 This CVE-2023-3635 seems to be false positive. There is no relation between graphql & guava libraries. We are expecting some bug with trivy. Will try to find out if there is any other solution.
Testing :

compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing