### PR TITLE
OP-21877 Upgrade graphql-java to 21.4 to fix the CVE-2023-2976

### DIFF
--- a/gate-web/gate-web.gradle
+++ b/gate-web/gate-web.gradle
@@ -49,6 +49,10 @@ dependencies {
 
   implementation "com.graphql-java-kickstart:graphql-spring-boot-starter:7.0.1"
   implementation "com.graphql-java-kickstart:graphql-java-tools:6.0.2"
+  implementation ("com.graphql-java:graphql-java:21.4") {
+    force(true)
+  }
+
   implementation "org.apache.groovy:groovy-json"
   runtimeOnly "io.spinnaker.kork:kork-runtime"
   runtimeOnly "org.springframework.boot:spring-boot-properties-migrator"


### PR DESCRIPTION
Jira : https://devopsmx.atlassian.net/browse/OP-21877
Summary : Upgraded graphql-java jar to 21.4. guava version also upgraded.
Testing :

compile successful, no new TCs failed bcoz of this.
service started successfully after this change.
Created trivy-scan locally, this CVE not found
Pre-merge : NA
Post-merge : QA regression testing